### PR TITLE
Cast callback pointer type

### DIFF
--- a/appkit_gen2/board_init.c
+++ b/appkit_gen2/board_init.c
@@ -279,13 +279,13 @@ void BOARD_Power_Init()
 void BOARD_BUTTON1_Init(BOARD_Callback_t user_cb)
 {
 	ARM_DRIVER_GPIO *BOARD_BUTTON1_GPIOdrv = &ARM_Driver_GPIO_(BOARD_BUTTON1_GPIO_PORT);
-	BOARD_BUTTON1_GPIOdrv->Initialize(BOARD_BUTTON1_PIN_NO, user_cb);
+	BOARD_BUTTON1_GPIOdrv->Initialize(BOARD_BUTTON1_PIN_NO, (ARM_GPIO_SignalEvent_t)user_cb);
 }
 
 void BOARD_BUTTON2_Init(BOARD_Callback_t user_cb)
 {
 	ARM_DRIVER_GPIO *BOARD_BUTTON2_GPIOdrv = &ARM_Driver_GPIO_(BOARD_BUTTON2_GPIO_PORT);
-	BOARD_BUTTON2_GPIOdrv->Initialize(BOARD_BUTTON2_PIN_NO, user_cb);
+	BOARD_BUTTON2_GPIOdrv->Initialize(BOARD_BUTTON2_PIN_NO, (ARM_GPIO_SignalEvent_t)user_cb);
 }
 
 void BOARD_BUTTON1_Control(BOARD_BUTTON_CONTROL control)

--- a/devkit_e1c/board_init.c
+++ b/devkit_e1c/board_init.c
@@ -277,13 +277,13 @@ void BOARD_Power_Init()
 void BOARD_BUTTON1_Init(BOARD_Callback_t user_cb)
 {
 	ARM_DRIVER_GPIO *BOARD_BUTTON1_GPIOdrv = &ARM_Driver_GPIO_(BOARD_BUTTON1_GPIO_PORT);
-	BOARD_BUTTON1_GPIOdrv->Initialize(BOARD_BUTTON1_PIN_NO, user_cb);
+	BOARD_BUTTON1_GPIOdrv->Initialize(BOARD_BUTTON1_PIN_NO, (ARM_GPIO_SignalEvent_t)user_cb);
 }
 
 void BOARD_BUTTON2_Init(BOARD_Callback_t user_cb)
 {
 	ARM_DRIVER_GPIO *BOARD_BUTTON2_GPIOdrv = &ARM_Driver_GPIO_(BOARD_BUTTON2_GPIO_PORT);
-	BOARD_BUTTON2_GPIOdrv->Initialize(BOARD_BUTTON2_PIN_NO, user_cb);
+	BOARD_BUTTON2_GPIOdrv->Initialize(BOARD_BUTTON2_PIN_NO, (ARM_GPIO_SignalEvent_t)user_cb);
 }
 
 void BOARD_BUTTON1_Control(BOARD_BUTTON_CONTROL control)

--- a/devkit_gen2/board_init.c
+++ b/devkit_gen2/board_init.c
@@ -290,13 +290,13 @@ void BOARD_Power_Init()
 void BOARD_BUTTON1_Init(BOARD_Callback_t user_cb)
 {
 	ARM_DRIVER_GPIO *BOARD_BUTTON1_GPIOdrv = &ARM_Driver_GPIO_(BOARD_BUTTON1_GPIO_PORT);
-	BOARD_BUTTON1_GPIOdrv->Initialize(BOARD_BUTTON1_PIN_NO, user_cb);
+	BOARD_BUTTON1_GPIOdrv->Initialize(BOARD_BUTTON1_PIN_NO, (ARM_GPIO_SignalEvent_t)user_cb);
 }
 
 void BOARD_BUTTON2_Init(BOARD_Callback_t user_cb)
 {
 	ARM_DRIVER_GPIO *BOARD_BUTTON2_GPIOdrv = &ARM_Driver_GPIO_(BOARD_BUTTON2_GPIO_PORT);
-	BOARD_BUTTON2_GPIOdrv->Initialize(BOARD_BUTTON2_PIN_NO, user_cb);
+	BOARD_BUTTON2_GPIOdrv->Initialize(BOARD_BUTTON2_PIN_NO, (ARM_GPIO_SignalEvent_t)user_cb);
 }
 
 void BOARD_BUTTON1_Control(BOARD_BUTTON_CONTROL control)


### PR DESCRIPTION
GCC 14.2 gives an error if type is not casted. In this case callback types are compatible.